### PR TITLE
Add support for accessing the API entrance point and checking authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ client = ActionNetworkRest.new(api_key: YOUR_API_KEY)
 # Check that our API key is working. Returns true or false.
 client.entry_point.authenticated_successfully?
 
+# See information about Action Network API endpoints
+client.entry_point.get
+
 # Retrieve a Person's data
 person = client.people.get(person_actionnetwork_identifier)
 puts person.email_addresses

--- a/README.md
+++ b/README.md
@@ -23,9 +23,8 @@ Or install it yourself as:
 ```
 client = ActionNetworkRest.new(api_key: YOUR_API_KEY)
 
-# Check that our API key is working
-check = client.entry_point.check_authentication
-puts check[:authenticated_response] # true or false
+# Check that our API key is working. Returns true or false.
+client.entry_point.authenticated_successfully?
 
 # Retrieve a Person's data
 person = client.people.get(person_actionnetwork_identifier)

--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ Or install it yourself as:
 ```
 client = ActionNetworkRest.new(api_key: YOUR_API_KEY)
 
+# Check that our API key is working
+check = client.entry_point.check_authentication
+puts check[:authenticated_response] # true or false
+
 # Retrieve a Person's data
 person = client.people.get(person_actionnetwork_identifier)
 puts person.email_addresses

--- a/lib/action_network_rest.rb
+++ b/lib/action_network_rest.rb
@@ -13,4 +13,5 @@ end
 require "action_network_rest/version"
 require "action_network_rest/client"
 
+require 'action_network_rest/entry_point'
 require 'action_network_rest/people'

--- a/lib/action_network_rest/client.rb
+++ b/lib/action_network_rest/client.rb
@@ -23,6 +23,10 @@ module ActionNetworkRest
 
     ## Helpers to let users do things like `an_client.people.create(params)`
 
+    def entry_point
+      @_entry_point ||= ActionNetworkRest::EntryPoint.new(client: self)
+    end
+
     def people
       @_people ||= ActionNetworkRest::People.new(client: self)
     end

--- a/lib/action_network_rest/entry_point.rb
+++ b/lib/action_network_rest/entry_point.rb
@@ -9,14 +9,13 @@ module ActionNetworkRest
       response.body
     end
 
-    def check_authentication
+    def authenticated_successfully?
       response_body = get
 
       # If we successfully authenticated, the entrypoint response will include a reference to tags.
       # If not (API key missing or wrong), the response will not include anything about tags,
       # but will otherwise be successful.
-      authenticated = response_body.dig('_links', 'osdi:tags').present?
-      {authenticated_response: authenticated}
+      response_body.dig('_links', 'osdi:tags').present?
     end
   end
 end

--- a/lib/action_network_rest/entry_point.rb
+++ b/lib/action_network_rest/entry_point.rb
@@ -1,0 +1,22 @@
+module ActionNetworkRest
+  class EntryPoint < Vertebrae::Model
+    def base_path
+      ''
+    end
+
+    def get
+      response = client.get_request base_path
+      response.body
+    end
+
+    def check_authentication
+      response_body = get
+
+      # If we successfully authenticated, the entrypoint response will include a reference to tags.
+      # If not (API key missing or wrong), the response will not include anything about tags,
+      # but will otherwise be successful.
+      authenticated = response_body.dig('_links', 'osdi:tags').present?
+      {authenticated_response: authenticated}
+    end
+  end
+end

--- a/spec/entry_point_spec.rb
+++ b/spec/entry_point_spec.rb
@@ -1,0 +1,67 @@
+require 'spec_helper'
+
+describe ActionNetworkRest::EntryPoint do
+  let(:api_key) { 'secret_key' }
+
+  subject { ActionNetworkRest.new(api_key: api_key) }
+
+  describe '#get' do
+    let(:response_body) { {some: 'data'}.to_json }
+
+    before :each do
+      stub_actionnetwork_request('/', method: :get).to_return(status: 200, body: response_body)
+    end
+
+    it 'should return the response' do
+      expect(subject.entry_point.get).to eq({'some' => 'data'})
+    end
+  end
+
+  describe '#check_authentication' do
+    before :each do
+      stub_actionnetwork_request('/', method: :get).to_return(status: 200, body: response_body)
+    end
+
+    context 'response includes tags' do
+      let(:response_body) do
+        {
+          motd: 'Welcome!',
+          _links: {
+            'osdi:petitions' => {
+              title: 'some petitions',
+              href: 'https://actionnetwork.org/api/v2/petitions'
+            },
+            'osdi:tags' => {
+              title: 'your tags',
+              href: 'https://actionnetwork.org/api/v2/tags'
+            }
+          }
+        }.to_json
+      end
+
+      it 'should return true' do
+        answer = subject.entry_point.check_authentication
+        expect(answer[:authenticated_response]).to be_truthy
+      end
+    end
+
+    context 'response does not include tags' do
+      let(:response_body) do
+        {
+          motd: 'Welcome!',
+          _links: {
+            'osdi:petitions' => {
+              title: 'some petitions',
+              href: 'https://actionnetwork.org/api/v2/petitions'
+            }
+          }
+        }.to_json
+      end
+
+      it 'should return false' do
+        answer = subject.entry_point.check_authentication
+        expect(answer[:authenticated_response]).to be_falsey
+      end
+    end
+  end
+end

--- a/spec/entry_point_spec.rb
+++ b/spec/entry_point_spec.rb
@@ -17,7 +17,7 @@ describe ActionNetworkRest::EntryPoint do
     end
   end
 
-  describe '#check_authentication' do
+  describe '#authenticated_successfully?' do
     before :each do
       stub_actionnetwork_request('/', method: :get).to_return(status: 200, body: response_body)
     end
@@ -40,8 +40,7 @@ describe ActionNetworkRest::EntryPoint do
       end
 
       it 'should return true' do
-        answer = subject.entry_point.check_authentication
-        expect(answer[:authenticated_response]).to be_truthy
+        expect(subject.entry_point.authenticated_successfully?).to be_truthy
       end
     end
 
@@ -59,8 +58,7 @@ describe ActionNetworkRest::EntryPoint do
       end
 
       it 'should return false' do
-        answer = subject.entry_point.check_authentication
-        expect(answer[:authenticated_response]).to be_falsey
+        expect(subject.entry_point.authenticated_successfully?).to be_falsey
       end
     end
   end


### PR DESCRIPTION
This adds a method for accessing the top-level API entrance point at https://actionnetwork.org/api/v2:
```
> client.entry_point.get
```

Accessing this endpoint can tell us whether the API key we're using is valid, because the response will include information about **tags** when the caller is authenticated. So this PR also adds a helper method to perform this check:
```
> client.entry_point.check_authentication

{"authenticated_response" => true }
```