### PR TITLE
Add support for petition endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,17 @@ puts person.email_addresses
 # Create a new Person
 person = client.people.create(email_addresses: [{address: 'foo@example.com'}])
 puts person.identifiers
+
+# Retrieve a Petition
+petition = client.petitions.get(petition_actionnetwork_identifier)
+puts petition.title
+
+# Create a new Petition
+petition = client.petitions.create({title: 'Do the Thing!'}, creator_person_id: person_actionnetwork_identifier)
+puts petition.identifiers
+
+# Update a Petition
+client.petitions.update(petition_actionnetwork_identifier, {description: 'An updated description'})
 ```
 
 ## Development

--- a/lib/action_network_rest.rb
+++ b/lib/action_network_rest.rb
@@ -12,6 +12,8 @@ end
 
 require "action_network_rest/version"
 require "action_network_rest/client"
+require 'action_network_rest/base'
 
 require 'action_network_rest/entry_point'
 require 'action_network_rest/people'
+require 'action_network_rest/petitions'

--- a/lib/action_network_rest/base.rb
+++ b/lib/action_network_rest/base.rb
@@ -1,0 +1,14 @@
+module ActionNetworkRest
+  class Base < Vertebrae::Model
+    def get(id)
+      response = client.get_request "#{base_path}#{url_escape(id)}"
+      response.body
+    end
+
+    private
+
+    def url_escape(string)
+      CGI.escape(string.to_s)
+    end
+  end
+end

--- a/lib/action_network_rest/base.rb
+++ b/lib/action_network_rest/base.rb
@@ -10,5 +10,9 @@ module ActionNetworkRest
     def url_escape(string)
       CGI.escape(string.to_s)
     end
+
+    def action_network_url(path)
+      client.connection.configuration.endpoint + path
+    end
   end
 end

--- a/lib/action_network_rest/client.rb
+++ b/lib/action_network_rest/client.rb
@@ -30,5 +30,9 @@ module ActionNetworkRest
     def people
       @_people ||= ActionNetworkRest::People.new(client: self)
     end
+
+    def petitions
+      @_petitions ||= ActionNetworkRest::Petitions.new(client: self)
+    end
   end
 end

--- a/lib/action_network_rest/people.rb
+++ b/lib/action_network_rest/people.rb
@@ -1,12 +1,7 @@
 module ActionNetworkRest
-  class People < Vertebrae::Model
+  class People < Base
     def base_path
       'people/'
-    end
-
-    def get(id)
-      response = client.get_request "#{base_path}#{url_escape(id)}"
-      response.body
     end
 
     def create(person_data, tags: [])
@@ -17,12 +12,6 @@ module ActionNetworkRest
 
       response = client.post_request base_path, post_body
       response.body
-    end
-
-    private
-
-    def url_escape(string)
-      CGI.escape(string.to_s)
     end
   end
 end

--- a/lib/action_network_rest/petitions.rb
+++ b/lib/action_network_rest/petitions.rb
@@ -14,5 +14,11 @@ module ActionNetworkRest
       response = client.post_request base_path, post_body
       response.body
     end
+
+    def update(id, petition_data)
+      petition_path = "#{base_path}#{url_escape(id)}"
+      response = client.put_request petition_path, petition_data
+      response.body
+    end
   end
 end

--- a/lib/action_network_rest/petitions.rb
+++ b/lib/action_network_rest/petitions.rb
@@ -3,5 +3,16 @@ module ActionNetworkRest
     def base_path
       'petitions/'
     end
+
+    def create(petition_data, creator_person_id: nil)
+      post_body = petition_data
+      if creator_person_id.present?
+        creator_person_url = action_network_url("/people/#{url_escape(creator_person_id)}")
+        post_body['_links'] = {'osdi:creator' => {href: creator_person_url}}
+      end
+
+      response = client.post_request base_path, post_body
+      response.body
+    end
   end
 end

--- a/lib/action_network_rest/petitions.rb
+++ b/lib/action_network_rest/petitions.rb
@@ -1,0 +1,7 @@
+module ActionNetworkRest
+  class Petitions < Base
+    def base_path
+      'petitions/'
+    end
+  end
+end

--- a/spec/petitions_spec.rb
+++ b/spec/petitions_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+describe ActionNetworkRest::Petitions do
+  let(:api_key) { 'secret_key' }
+
+  subject { ActionNetworkRest.new(api_key: api_key) }
+
+  describe '#get' do
+    let(:petition_id) { 'abc-def-123-456' }
+    let(:response_body) do
+      {
+        identifiers: ["action_network:#{petition_id}"],
+        title: 'Do the Thing',
+        description: 'It is oh so important',
+        petition_text: 'Please, do the thing.'
+      }.to_json
+    end
+
+    before :each do
+      stub_actionnetwork_request("/petitions/#{petition_id}", method: :get)
+        .to_return(status: 200, body: response_body)
+    end
+
+    it 'should retrieve petition data' do
+      petition = subject.petitions.get(petition_id)
+      expect(petition.title).to eq 'Do the Thing'
+    end
+  end
+end

--- a/spec/petitions_spec.rb
+++ b/spec/petitions_spec.rb
@@ -26,4 +26,52 @@ describe ActionNetworkRest::Petitions do
       expect(petition.title).to eq 'Do the Thing'
     end
   end
+
+  describe '#create' do
+    let(:petition_data) do
+      {
+        identifiers: ['somesystem:123'],
+        title: 'Do the Thing!',
+        origin_system: 'Some System'
+      }
+    end
+    let(:request_body) { petition_data }
+    let(:response_body) do
+      {
+        identifiers: ['somesystem:123', 'action_network:123-456-789-abc'],
+        title: 'Do the Thing!',
+        origin_system: 'Some System'
+      }.to_json
+    end
+    let!(:post_stub) do
+      stub_actionnetwork_request('/petitions/', method: :post, body: request_body)
+        .to_return(status: 200, body: response_body)
+    end
+
+    it 'should POST petition data' do
+      petition = subject.petitions.create(petition_data)
+
+      expect(post_stub).to have_been_requested
+
+      expect(petition.identifiers).to contain_exactly('action_network:123-456-789-abc',
+                                                      'somesystem:123')
+    end
+
+    context 'with a creator_person_id' do
+      let(:person_id) { 'c945d6fe-929e-11e3-a2e9-12313d316c29' }
+      let(:person_url) { "https://actionnetwork.org/api/v2/people/#{person_id}" }
+      let(:request_body) do
+        petition_data.merge({'_links' => {'osdi:creator' => {'href' => person_url}}})
+      end
+
+      it 'should include a link to the creator' do
+        petition = subject.petitions.create(petition_data, creator_person_id: person_id)
+
+        expect(post_stub).to have_been_requested
+
+        expect(petition.identifiers).to contain_exactly('action_network:123-456-789-abc',
+                                                        'somesystem:123')
+      end
+    end
+  end
 end

--- a/spec/petitions_spec.rb
+++ b/spec/petitions_spec.rb
@@ -74,4 +74,35 @@ describe ActionNetworkRest::Petitions do
       end
     end
   end
+
+  describe '#update' do
+    let(:petition_data) do
+      {
+        identifiers: ['somesystem:123'],
+        title: 'Do the Thing!',
+        origin_system: 'Some System'
+      }
+    end
+    let(:petition_id) { '123-456-789-abc' }
+    let(:response_body) do
+      {
+        identifiers: ['somesystem:123', "action_network:#{petition_id}"],
+        title: 'Do the Thing!',
+        origin_system: 'Some System'
+      }.to_json
+    end
+    let!(:put_stub) do
+      stub_actionnetwork_request("/petitions/#{petition_id}", method: :put, body: petition_data)
+        .to_return(status: 200, body: response_body)
+    end
+
+    it 'should PUT petition data' do
+      updated_petition = subject.petitions.update(petition_id, petition_data)
+
+      expect(put_stub).to have_been_requested
+
+      expect(updated_petition.identifiers).to contain_exactly('action_network:123-456-789-abc',
+                                                              'somesystem:123')
+    end
+  end
 end


### PR DESCRIPTION
This adds methods for interacting with the [petitions endpoints](https://actionnetwork.org/docs/v2/petitions) of the ActionNetwork API.

Create petition
```
client.petitions.create({title: 'Do the Thing!', origin_system: 'ControlShift'}, creator_person_id: 'abc-123-4567')
```

Get petition
```
client.petitions.get(petition_id)
```

Update petition
```
client.petitions.update(petition_id, {description: 'updated description'})
```