### PR TITLE
Add action_network_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,24 +29,24 @@ client.entry_point.authenticated_successfully?
 # See information about Action Network API endpoints
 client.entry_point.get
 
-# Retrieve a Person's data
-person = client.people.get(person_actionnetwork_identifier)
-puts person.email_addresses
-
 # Create a new Person
 person = client.people.create(email_addresses: [{address: 'foo@example.com'}])
-puts person.identifiers
+person_id = person.action_network_id
 
-# Retrieve a Petition
-petition = client.petitions.get(petition_actionnetwork_identifier)
-puts petition.title
+# Retrieve a Person's data
+person = client.people.get(person_id)
+puts person.email_addresses
 
 # Create a new Petition
 petition = client.petitions.create({title: 'Do the Thing!'}, creator_person_id: person_actionnetwork_identifier)
-puts petition.identifiers
+petition_id = petition.action_network_id
+
+# Retrieve a Petition
+petition = client.petitions.get(petition_id)
+puts petition.title
 
 # Update a Petition
-client.petitions.update(petition_actionnetwork_identifier, {description: 'An updated description'})
+client.petitions.update(petition_id, {description: 'An updated description'})
 ```
 
 ## Development

--- a/lib/action_network_rest/base.rb
+++ b/lib/action_network_rest/base.rb
@@ -2,13 +2,27 @@ module ActionNetworkRest
   class Base < Vertebrae::Model
     def get(id)
       response = client.get_request "#{base_path}#{url_escape(id)}"
-      response.body
+      object_from_response(response)
     end
 
     private
 
     def url_escape(string)
       CGI.escape(string.to_s)
+    end
+
+    def object_from_response(response)
+      obj = response.body
+
+      identifiers = obj[:identifiers] || []
+      qualified_actionnetwork_id = identifiers.find do |id|
+        id.split(':').first == 'action_network'
+      end
+      if qualified_actionnetwork_id.present?
+        obj.action_network_id = qualified_actionnetwork_id.sub(/^action_network:/, '')
+      end
+
+      obj
     end
 
     def action_network_url(path)

--- a/lib/action_network_rest/base.rb
+++ b/lib/action_network_rest/base.rb
@@ -14,6 +14,16 @@ module ActionNetworkRest
     def object_from_response(response)
       obj = response.body
 
+      # The response we get from Action Network may contain an "identifiers" block that looks something like:
+      #
+      # "identifiers": [
+      #   "action_network:d6bdf50e-c3a4-4981-a948-3d8c086066d7",
+      #   "some_external_system:1",
+      #   "another_external_system:57"
+      # ]
+      #
+      # If so, we pull out the action_network identifier and stick it in a top-level key "action_network_id",
+      # for the convenience of callers using the returned object.
       identifiers = obj[:identifiers] || []
       qualified_actionnetwork_id = identifiers.find do |id|
         id.split(':').first == 'action_network'

--- a/lib/action_network_rest/people.rb
+++ b/lib/action_network_rest/people.rb
@@ -11,7 +11,7 @@ module ActionNetworkRest
       end
 
       response = client.post_request base_path, post_body
-      response.body
+      object_from_response(response)
     end
   end
 end

--- a/lib/action_network_rest/petitions.rb
+++ b/lib/action_network_rest/petitions.rb
@@ -12,13 +12,13 @@ module ActionNetworkRest
       end
 
       response = client.post_request base_path, post_body
-      response.body
+      object_from_response(response)
     end
 
     def update(id, petition_data)
       petition_path = "#{base_path}#{url_escape(id)}"
       response = client.put_request petition_path, petition_data
-      response.body
+      object_from_response(response)
     end
   end
 end

--- a/spec/people_spec.rb
+++ b/spec/people_spec.rb
@@ -58,6 +58,7 @@ describe ActionNetworkRest::People do
       expect(post_stub).to have_been_requested
 
       expect(person.identifiers).to contain_exactly('action_network:123-456-789')
+      expect(person.action_network_id).to eq '123-456-789'
     end
 
     context 'with tags' do
@@ -74,6 +75,7 @@ describe ActionNetworkRest::People do
         expect(post_stub).to have_been_requested
 
         expect(person.identifiers).to contain_exactly('action_network:123-456-789')
+        expect(person.action_network_id).to eq '123-456-789'
       end
     end
   end

--- a/spec/petitions_spec.rb
+++ b/spec/petitions_spec.rb
@@ -55,6 +55,7 @@ describe ActionNetworkRest::Petitions do
 
       expect(petition.identifiers).to contain_exactly('action_network:123-456-789-abc',
                                                       'somesystem:123')
+      expect(petition.action_network_id).to eq '123-456-789-abc'
     end
 
     context 'with a creator_person_id' do
@@ -69,8 +70,7 @@ describe ActionNetworkRest::Petitions do
 
         expect(post_stub).to have_been_requested
 
-        expect(petition.identifiers).to contain_exactly('action_network:123-456-789-abc',
-                                                        'somesystem:123')
+        expect(petition.action_network_id).to eq '123-456-789-abc'
       end
     end
   end


### PR DESCRIPTION
This updates the objects we return from the get/create/update methods for petitions and people, so that instead of doing
```
petition.identifiers.find{|id| id.starts_with?('action_network:')}.sub(/^action_network:/, '')
```

callers can just do
```
petition.action_network_id
```

This will be useful for writing an integration that needs to e.g. store the Action Network identifier for a synced petition.