### PR TITLE
Add support for unsubscribing

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ person_id = person.action_network_id
 person = client.people.get(person_id)
 puts person.email_addresses
 
+# Unsubscribe a Person
+client.people.unsubscribe(person_id)
+
 # Create a new Petition
 petition = client.petitions.create({title: 'Do the Thing!'}, creator_person_id: person_id)
 petition_id = petition.action_network_id

--- a/lib/action_network_rest/people.rb
+++ b/lib/action_network_rest/people.rb
@@ -13,5 +13,11 @@ module ActionNetworkRest
       response = client.post_request base_path, post_body
       object_from_response(response)
     end
+
+    def unsubscribe(id)
+      request_body = {email_addresses: [{status: 'unsubscribed'}]}
+      response = client.put_request "#{base_path}#{url_escape(id)}", request_body
+      object_from_response(response)
+    end
   end
 end

--- a/spec/people_spec.rb
+++ b/spec/people_spec.rb
@@ -79,4 +79,39 @@ describe ActionNetworkRest::People do
       end
     end
   end
+
+  describe '#unsubscribe' do
+    let(:person_id) { 'abc-def-123-456' }
+    let(:request_body) do
+      {
+        email_addresses: [
+          { status: 'unsubscribed' }
+        ]
+      }
+    end
+    let(:response_body) do
+      {
+        identifiers: ["action_network:#{person_id}"],
+        email_addresses: [
+          {
+            primary: true,
+            address: 'jane@example.com',
+            status: 'unsubscribed'
+          }
+        ]
+      }.to_json
+    end
+    let!(:put_stub) do
+      stub_actionnetwork_request("/people/#{person_id}", method: :put, body: request_body)
+        .to_return(status: 200, body: response_body)
+    end
+
+    it 'should PUT the unsubscribe request' do
+      updated_person = subject.people.unsubscribe(person_id)
+
+      expect(put_stub).to have_been_requested
+
+      expect(updated_person.action_network_id).to eq person_id
+    end
+  end
 end


### PR DESCRIPTION
This adds support for [unsubscribing a Person](https://actionnetwork.org/docs/v2/delete/) via the Action Network API.

```
client.people.unsubscribe(person_id)
```