### PR TITLE
Parse person ID from response when creating a signature

### DIFF
--- a/lib/action_network_rest/signatures.rb
+++ b/lib/action_network_rest/signatures.rb
@@ -13,7 +13,16 @@ module ActionNetworkRest
       end
 
       response = client.post_request base_path, post_body
-      object_from_response(response)
+      response_object = object_from_response(response)
+
+      if response_object[:_links].any? && !response_object[:_links][:'osdi:person'].nil?
+        person_href = response_object[:_links][:'osdi:person'][:href]
+        people_base_url = action_network_url('/people')
+        person_id = person_href.match(%r{#{people_base_url}\/(?<person_id>.+)\Z}).named_captures['person_id']
+        response_object.person_id = person_id
+      end
+
+      response_object
     end
 
     def update(id, signature_data)

--- a/lib/action_network_rest/version.rb
+++ b/lib/action_network_rest/version.rb
@@ -1,3 +1,3 @@
 module ActionNetworkRest
-  VERSION = "0.3.0"
+  VERSION = "0.3.1"
 end

--- a/spec/signatures_spec.rb
+++ b/spec/signatures_spec.rb
@@ -29,6 +29,7 @@ describe ActionNetworkRest::Signatures do
 
   describe '#create' do
     let(:petition_id) { 'abc-def-123-456' }
+    let(:person_id) { 'c945d6fe-929e-11e3-a2e9-12313d316c29' }
     let(:signature_data) do
       {
         identifiers: ['some_system:123'],
@@ -47,7 +48,8 @@ describe ActionNetworkRest::Signatures do
       {
         identifiers: ["action_network:#{signature_id}"],
         'action_network:person_id' => '699da712-929f-11e3-a2e9-12313d316c29',
-        'action_network:petition_id' => petition_id
+        'action_network:petition_id' => petition_id,
+        '_links' => { 'osdi:person' => { 'href' => "https://actionnetwork.org/api/v2/people/#{person_id}" } }
       }.to_json
     end
 
@@ -62,6 +64,12 @@ describe ActionNetworkRest::Signatures do
       expect(post_stub).to have_been_requested
 
       expect(signature.action_network_id).to eq signature_id
+    end
+
+    it 'should parse person ID and return in person_id' do
+      signature = subject.petitions(petition_id).signatures.create(signature_data)
+
+      expect(signature.person_id).to eq person_id
     end
 
     context 'with tags' do


### PR DESCRIPTION
Needed for being able to create the person along with the signature in a single API call