### PR TITLE
New Base#list and Tag#find_ by_name methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,17 @@ client.entry_point.get
 person = client.people.create(email_addresses: [{address: 'foo@example.com'}])
 person_id = person.action_network_id
 
+# List people
+people = client.people.list
+
+# Iterate over a list of people
+page_number = 1
+loop do
+  people = client.people.list(page: page_number)
+  break if people.empty?
+  page_number += 1
+end
+
 # Retrieve a Person's data
 person = client.people.get(person_id)
 puts person.email_addresses
@@ -77,6 +88,9 @@ tag_id = tag.action_network_id
 
 # Retrieve a Tag
 tag = client.tags.get(tag_id)
+
+# Retrieve a Tag by name
+tag = client.tags.find_by_name('Volunteers')
 
 # Apply a Tag to a Person
 tagging = client.tags(tag_id).create({identifiers: ['external:123']}, person_id: person_id)

--- a/lib/action_network_rest/base.rb
+++ b/lib/action_network_rest/base.rb
@@ -8,6 +8,8 @@ module ActionNetworkRest
     def list(page: 1)
       response = client.get_request "#{base_path}?page=#{page}"
       objects = response.body.dig('_embedded', osdi_key)
+      return [] if objects.nil?
+
       objects.each { |obj| object_with_action_network_id(obj) }
 
       objects

--- a/lib/action_network_rest/base.rb
+++ b/lib/action_network_rest/base.rb
@@ -5,6 +5,14 @@ module ActionNetworkRest
       object_from_response(response)
     end
 
+    def list(page: 1)
+      response = client.get_request "#{base_path}?page=#{page}"
+      objects = response.body.dig('_embedded', osdi_key)
+      objects.each { |obj| object_with_action_network_id(obj) }
+
+      objects
+    end
+
     private
 
     def url_escape(string)

--- a/lib/action_network_rest/base.rb
+++ b/lib/action_network_rest/base.rb
@@ -10,7 +10,7 @@ module ActionNetworkRest
       objects = response.body.dig('_embedded', osdi_key)
       return [] if objects.nil?
 
-      objects.each { |obj| object_with_action_network_id(obj) }
+      objects.each { |obj| set_action_network_id_on_object(obj) }
 
       objects
     end
@@ -21,7 +21,7 @@ module ActionNetworkRest
       CGI.escape(string.to_s)
     end
 
-    def object_with_action_network_id(obj)
+    def set_action_network_id_on_object(obj)
       # Takes an object which may contain an `identifiers` key, which may contain an action_network identifier
       # If so, we pull out the action_network identifier and stick it in a top-level key "action_network_id",
       # for the convenience of callers using the returned object.
@@ -43,7 +43,7 @@ module ActionNetworkRest
 
     def object_from_response(response)
       obj = response.body
-      object_with_action_network_id(obj)
+      set_action_network_id_on_object(obj)
     end
 
     def action_network_url(path)

--- a/lib/action_network_rest/people.rb
+++ b/lib/action_network_rest/people.rb
@@ -35,10 +35,16 @@ module ActionNetworkRest
       #
       url_encoded_filter_string = url_escape("email_address eq '#{email}'")
       response = client.get_request "#{base_path}?filter=#{url_encoded_filter_string}"
-      person_object = response.body[:_embedded]['osdi:people'].first
+      person_object = response.body[:_embedded][osdi_key].first
       if person_object.present?
         object_with_action_network_id(person_object)
       end
+    end
+
+    private
+
+    def osdi_key
+      'osdi:people'
     end
   end
 end

--- a/lib/action_network_rest/people.rb
+++ b/lib/action_network_rest/people.rb
@@ -37,7 +37,7 @@ module ActionNetworkRest
       response = client.get_request "#{base_path}?filter=#{url_encoded_filter_string}"
       person_object = response.body[:_embedded][osdi_key].first
       if person_object.present?
-        object_with_action_network_id(person_object)
+        set_action_network_id_on_object(person_object)
       end
     end
 

--- a/lib/action_network_rest/petitions.rb
+++ b/lib/action_network_rest/petitions.rb
@@ -33,5 +33,11 @@ module ActionNetworkRest
       response = client.put_request petition_path, petition_data
       object_from_response(response)
     end
+
+    private
+
+    def osdi_key
+      'osdi:petitions'
+    end
   end
 end

--- a/lib/action_network_rest/signatures.rb
+++ b/lib/action_network_rest/signatures.rb
@@ -20,5 +20,11 @@ module ActionNetworkRest
       response = client.put_request "#{base_path}#{url_escape(id)}", signature_data
       object_from_response(response)
     end
+
+    private
+
+    def osdi_key
+      'osdi:signatures'
+    end
   end
 end

--- a/lib/action_network_rest/taggings.rb
+++ b/lib/action_network_rest/taggings.rb
@@ -19,5 +19,11 @@ module ActionNetworkRest
       response = client.delete_request "#{base_path}#{url_escape(id)}"
       object_from_response(response)
     end
+
+    private
+
+    def osdi_key
+      'osdi:taggings'
+    end
   end
 end

--- a/lib/action_network_rest/tags.rb
+++ b/lib/action_network_rest/tags.rb
@@ -22,5 +22,11 @@ module ActionNetworkRest
       response = client.post_request base_path, post_body
       object_from_response(response)
     end
+
+    private
+
+    def osdi_key
+      'osdi:tags'
+    end
   end
 end

--- a/lib/action_network_rest/tags.rb
+++ b/lib/action_network_rest/tags.rb
@@ -23,6 +23,22 @@ module ActionNetworkRest
       object_from_response(response)
     end
 
+    def find_by_name(name)
+      # Action Network API doesn't support currently OData querying for tags
+      # (https://actionnetwork.org/docs/v2#odata) so we need to retrieve a list of
+      # all tags and iterate to find the one we're looking for.
+      page = 1
+      loop do
+        tags = self.list(page: page)
+        return nil if tags.empty?
+
+        found_tag = tags.find { |t| t.name == name }
+        return found_tag unless found_tag.nil?
+
+        page += 1
+      end
+    end
+
     private
 
     def osdi_key

--- a/lib/action_network_rest/version.rb
+++ b/lib/action_network_rest/version.rb
@@ -1,3 +1,3 @@
 module ActionNetworkRest
-  VERSION = "0.4.0"
+  VERSION = "0.5.0"
 end

--- a/spec/people_spec.rb
+++ b/spec/people_spec.rb
@@ -32,6 +32,97 @@ describe ActionNetworkRest::People do
     end
   end
 
+  describe '#list' do
+    let(:response_body) do
+      {
+        _embedded: {
+          'osdi:people' => [
+            {
+              identifiers: [ 'action_network:d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3' ],
+              given_name: 'John',
+              family_name: 'Smith',
+              email_addresses: [
+                {
+                  primary: true,
+                  address: 'johnsmith@mail.com',
+                  status: 'subscribed'
+                }
+              ],
+            },
+            {
+              identifiers: [ 'action_network:1efc3644-af25-4253-90b8-a0baf12dbd1e' ],
+              given_name: 'Jane',
+              family_name: 'Doe',
+              email_addresses: [
+                {
+                  primary: true,
+                  address: 'janedoe@mail.com',
+                  status: 'unsubscribed'
+                }
+              ],
+            },
+          ]
+        }
+      }.to_json
+    end
+
+    context 'requesting first page' do
+      before :each do
+        stub_actionnetwork_request("/people/?page=1", method: :get)
+          .to_return(status: 200, body: response_body)
+      end
+
+      it 'should retrieve the people data from first page when calling without an argument' do
+        people = subject.people.list
+
+        expect(people.count).to eq 2
+        expect(people.first.action_network_id).to eq 'd91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3'
+        expect(people.first.given_name).to eq 'John'
+        expect(people.first.family_name).to eq 'Smith'
+        expect(people.first.email_addresses.first.address).to eq 'johnsmith@mail.com'
+        expect(people.last.action_network_id).to eq '1efc3644-af25-4253-90b8-a0baf12dbd1e'
+        expect(people.last.given_name).to eq 'Jane'
+        expect(people.last.family_name).to eq 'Doe'
+        expect(people.last.email_addresses.first.address).to eq 'janedoe@mail.com'
+      end
+
+      it 'should retrieve the people data from first page when calling with page argument' do
+        people = subject.people.list(page: 1)
+
+        expect(people.count).to eq 2
+        expect(people.first.action_network_id).to eq 'd91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3'
+        expect(people.first.given_name).to eq 'John'
+        expect(people.first.family_name).to eq 'Smith'
+        expect(people.first.email_addresses.first.address).to eq 'johnsmith@mail.com'
+        expect(people.last.action_network_id).to eq '1efc3644-af25-4253-90b8-a0baf12dbd1e'
+        expect(people.last.given_name).to eq 'Jane'
+        expect(people.last.family_name).to eq 'Doe'
+        expect(people.last.email_addresses.first.address).to eq 'janedoe@mail.com'
+      end
+    end
+
+    context 'requesting page 10' do
+      before :each do
+        stub_actionnetwork_request("/people/?page=10", method: :get)
+          .to_return(status: 200, body: response_body)
+      end
+
+      it 'should retrieve the people data from requested page number' do
+        people = subject.people.list(page: 10)
+
+        expect(people.count).to eq 2
+        expect(people.first.action_network_id).to eq 'd91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3'
+        expect(people.first.given_name).to eq 'John'
+        expect(people.first.family_name).to eq 'Smith'
+        expect(people.first.email_addresses.first.address).to eq 'johnsmith@mail.com'
+        expect(people.last.action_network_id).to eq '1efc3644-af25-4253-90b8-a0baf12dbd1e'
+        expect(people.last.given_name).to eq 'Jane'
+        expect(people.last.family_name).to eq 'Doe'
+        expect(people.last.email_addresses.first.address).to eq 'janedoe@mail.com'
+      end
+    end
+  end
+
   describe '#create' do
     let(:person_data) do
       {

--- a/spec/petitions_spec.rb
+++ b/spec/petitions_spec.rb
@@ -27,6 +27,69 @@ describe ActionNetworkRest::Petitions do
     end
   end
 
+  describe '#list' do
+    let(:response_body) do
+      {
+        _embedded: {
+          'osdi:petitions' => [
+            {
+              identifiers: [ 'action_network:a4dde5b6-0512-48ea-b4ad-63a71117b43d' ],
+              title: 'Stop doing the bad thing'
+            },
+            {
+              identifiers: [ 'action_network:a27178b9-45c3-4844-8ebf-ebd5da74a1e3' ],
+              title: 'We need to do this now!'
+            },
+          ]
+        }
+      }.to_json
+    end
+
+    context 'requesting first page' do
+      before :each do
+        stub_actionnetwork_request("/petitions/?page=1", method: :get)
+          .to_return(status: 200, body: response_body)
+      end
+
+      it 'should retrieve the petitions data from first page when calling without an argument' do
+        petitions = subject.petitions.list
+
+        expect(petitions.count).to eq 2
+        expect(petitions.first.action_network_id).to eq 'a4dde5b6-0512-48ea-b4ad-63a71117b43d'
+        expect(petitions.first.title).to eq 'Stop doing the bad thing'
+        expect(petitions.last.action_network_id).to eq 'a27178b9-45c3-4844-8ebf-ebd5da74a1e3'
+        expect(petitions.last.title).to eq 'We need to do this now!'
+      end
+
+      it 'should retrieve the petitions data from first page when calling with page argument' do
+        petitions = subject.petitions.list(page: 1)
+
+        expect(petitions.count).to eq 2
+        expect(petitions.first.action_network_id).to eq 'a4dde5b6-0512-48ea-b4ad-63a71117b43d'
+        expect(petitions.first.title).to eq 'Stop doing the bad thing'
+        expect(petitions.last.action_network_id).to eq 'a27178b9-45c3-4844-8ebf-ebd5da74a1e3'
+        expect(petitions.last.title).to eq 'We need to do this now!'
+      end
+    end
+
+    context 'requesting page 10' do
+      before :each do
+        stub_actionnetwork_request("/petitions/?page=10", method: :get)
+          .to_return(status: 200, body: response_body)
+      end
+
+      it 'should retrieve the petitions data from requested page number' do
+        petitions = subject.petitions.list(page: 10)
+
+        expect(petitions.count).to eq 2
+        expect(petitions.first.action_network_id).to eq 'a4dde5b6-0512-48ea-b4ad-63a71117b43d'
+        expect(petitions.first.title).to eq 'Stop doing the bad thing'
+        expect(petitions.last.action_network_id).to eq 'a27178b9-45c3-4844-8ebf-ebd5da74a1e3'
+        expect(petitions.last.title).to eq 'We need to do this now!'
+      end
+    end
+  end
+
   describe '#create' do
     let(:petition_data) do
       {

--- a/spec/signatures_spec.rb
+++ b/spec/signatures_spec.rb
@@ -27,6 +27,73 @@ describe ActionNetworkRest::Signatures do
     end
   end
 
+  describe '#list' do
+    let(:petition_id) { 'abc-def-123-456' }
+
+    let(:response_body) do
+      {
+        _embedded: {
+          'osdi:signatures' => [
+            {
+              identifiers: [ 'action_network:d6bdf50e-c3a4-4981-a948-3d8c086066d7' ],
+              'action_network:person_id' => '699da712-929f-11e3-a2e9-12313d316c29',
+              'action_network:petition_id' => petition_id
+            },
+            {
+              identifiers: [ 'action_network:71497ab2-b3e7-4896-af46-126ac7287dab' ],
+              'action_network:person_id' => 'c945d6fe-929e-11e3-a2e9-12313d316c29',
+              'action_network:petition_id' => petition_id
+            },
+          ]
+        }
+      }.to_json
+    end
+
+    context 'requesting first page' do
+      before :each do
+        stub_actionnetwork_request("/petitions/#{petition_id}/signatures/?page=1", method: :get)
+          .to_return(status: 200, body: response_body)
+      end
+
+      it 'should retrieve the signatures data from first page when calling without an argument' do
+        signatures = subject.petitions(petition_id).signatures.list
+
+        expect(signatures.count).to eq 2
+        expect(signatures.first.action_network_id).to eq 'd6bdf50e-c3a4-4981-a948-3d8c086066d7'
+        expect(signatures.first['action_network:person_id']).to eq '699da712-929f-11e3-a2e9-12313d316c29'
+        expect(signatures.last.action_network_id).to eq '71497ab2-b3e7-4896-af46-126ac7287dab'
+        expect(signatures.last['action_network:person_id']).to eq 'c945d6fe-929e-11e3-a2e9-12313d316c29'
+      end
+
+      it 'should retrieve the signatures data from first page when calling with page argument' do
+        signatures = subject.petitions(petition_id).signatures.list(page: 1)
+
+        expect(signatures.count).to eq 2
+        expect(signatures.first.action_network_id).to eq 'd6bdf50e-c3a4-4981-a948-3d8c086066d7'
+        expect(signatures.first['action_network:person_id']).to eq '699da712-929f-11e3-a2e9-12313d316c29'
+        expect(signatures.last.action_network_id).to eq '71497ab2-b3e7-4896-af46-126ac7287dab'
+        expect(signatures.last['action_network:person_id']).to eq 'c945d6fe-929e-11e3-a2e9-12313d316c29'
+      end
+    end
+
+    context 'requesting page 10' do
+      before :each do
+        stub_actionnetwork_request("/petitions/#{petition_id}/signatures/?page=10", method: :get)
+          .to_return(status: 200, body: response_body)
+      end
+
+      it 'should retrieve the signatures data from requested page number' do
+        signatures = subject.petitions(petition_id).signatures.list(page: 10)
+
+        expect(signatures.count).to eq 2
+        expect(signatures.first.action_network_id).to eq 'd6bdf50e-c3a4-4981-a948-3d8c086066d7'
+        expect(signatures.first['action_network:person_id']).to eq '699da712-929f-11e3-a2e9-12313d316c29'
+        expect(signatures.last.action_network_id).to eq '71497ab2-b3e7-4896-af46-126ac7287dab'
+        expect(signatures.last['action_network:person_id']).to eq 'c945d6fe-929e-11e3-a2e9-12313d316c29'
+      end
+    end
+  end
+
   describe '#create' do
     let(:petition_id) { 'abc-def-123-456' }
     let(:signature_data) do

--- a/spec/taggings_spec.rb
+++ b/spec/taggings_spec.rb
@@ -33,6 +33,65 @@ describe ActionNetworkRest::Taggings do
     end
   end
 
+  describe '#list' do
+    let(:tag_id) { '71f8feef-61c8-4e6b-9745-ec1d7752f298' }
+
+    let(:response_body) do
+      {
+        _embedded: {
+          'osdi:taggings' => [
+            { identifiers: [ 'action_network:82e909f9-1ac7-4952-bbd4-b4690a14bec2' ], item_type: 'osdi:person' },
+            { identifiers: [ 'action_network:a9ccd87c-97f4-48db-9e6b-507509091839' ], item_type: 'osdi:person' }
+          ]
+        }
+      }.to_json
+    end
+
+    context 'requesting first page' do
+      before :each do
+        stub_actionnetwork_request("/tags/#{tag_id}/taggings/?page=1", method: :get)
+          .to_return(status: 200, body: response_body)
+      end
+
+      it 'should retrieve the taggings data from first page when calling without an argument' do
+        taggings = subject.tags(tag_id).taggings.list
+
+        expect(taggings.count).to eq 2
+        expect(taggings.first.action_network_id).to eq '82e909f9-1ac7-4952-bbd4-b4690a14bec2'
+        expect(taggings.first.item_type).to eq 'osdi:person'
+        expect(taggings.last.action_network_id).to eq 'a9ccd87c-97f4-48db-9e6b-507509091839'
+        expect(taggings.last.item_type).to eq 'osdi:person'
+      end
+
+      it 'should retrieve the taggings data from first page when calling with page argument' do
+        taggings = subject.tags(tag_id).taggings.list(page: 1)
+
+        expect(taggings.count).to eq 2
+        expect(taggings.first.action_network_id).to eq '82e909f9-1ac7-4952-bbd4-b4690a14bec2'
+        expect(taggings.first.item_type).to eq 'osdi:person'
+        expect(taggings.last.action_network_id).to eq 'a9ccd87c-97f4-48db-9e6b-507509091839'
+        expect(taggings.last.item_type).to eq 'osdi:person'
+      end
+    end
+
+    context 'requesting page 10' do
+      before :each do
+        stub_actionnetwork_request("/tags/#{tag_id}/taggings/?page=10", method: :get)
+          .to_return(status: 200, body: response_body)
+      end
+
+      it 'should retrieve the taggings data from requested page number' do
+        taggings = subject.tags(tag_id).taggings.list(page: 10)
+
+        expect(taggings.count).to eq 2
+        expect(taggings.first.action_network_id).to eq '82e909f9-1ac7-4952-bbd4-b4690a14bec2'
+        expect(taggings.first.item_type).to eq 'osdi:person'
+        expect(taggings.last.action_network_id).to eq 'a9ccd87c-97f4-48db-9e6b-507509091839'
+        expect(taggings.last.item_type).to eq 'osdi:person'
+      end
+    end
+  end
+
   describe '#create' do
     let(:tag_id) { '71f8feef-61c8-4e6b-9745-ec1d7752f298' }
     let(:person_id) { 'c945d6fe-929e-11e3-a2e9-12313d316c29' }

--- a/spec/tags_spec.rb
+++ b/spec/tags_spec.rb
@@ -26,6 +26,63 @@ describe ActionNetworkRest::Tags do
     end
   end
 
+  describe '#list' do
+    let(:response_body) do
+      {
+        _embedded: {
+          'osdi:tags' => [
+            { identifiers: [ 'action_network:fc0a1ec6-5743-4b98-ae0c-cea8766b2212' ], name: 'Economic Justice' },
+            { identifiers: [ 'action_network:71f8feef-61c8-4e6b-9745-ec1d7752f298' ], name: 'Volunteers' }
+          ]
+        }
+      }.to_json
+    end
+
+    context 'requesting first page' do
+      before :each do
+        stub_actionnetwork_request("/tags/?page=1", method: :get)
+          .to_return(status: 200, body: response_body)
+      end
+
+      it 'should retrieve the tags data from first page when calling without an argument' do
+        tags = subject.tags.list
+
+        expect(tags.count).to eq 2
+        expect(tags.first.action_network_id).to eq 'fc0a1ec6-5743-4b98-ae0c-cea8766b2212'
+        expect(tags.first.name).to eq 'Economic Justice'
+        expect(tags.last.action_network_id).to eq '71f8feef-61c8-4e6b-9745-ec1d7752f298'
+        expect(tags.last.name).to eq 'Volunteers'
+      end
+
+      it 'should retrieve the tags data from first page when calling with page argument' do
+        tags = subject.tags.list(page: 1)
+
+        expect(tags.count).to eq 2
+        expect(tags.first.action_network_id).to eq 'fc0a1ec6-5743-4b98-ae0c-cea8766b2212'
+        expect(tags.first.name).to eq 'Economic Justice'
+        expect(tags.last.action_network_id).to eq '71f8feef-61c8-4e6b-9745-ec1d7752f298'
+        expect(tags.last.name).to eq 'Volunteers'
+      end
+    end
+
+    context 'requesting page 10' do
+      before :each do
+        stub_actionnetwork_request("/tags/?page=10", method: :get)
+          .to_return(status: 200, body: response_body)
+      end
+
+      it 'should retrieve the tags data from requested page number' do
+        tags = subject.tags.list(page: 10)
+
+        expect(tags.count).to eq 2
+        expect(tags.first.action_network_id).to eq 'fc0a1ec6-5743-4b98-ae0c-cea8766b2212'
+        expect(tags.first.name).to eq 'Economic Justice'
+        expect(tags.last.action_network_id).to eq '71f8feef-61c8-4e6b-9745-ec1d7752f298'
+        expect(tags.last.name).to eq 'Volunteers'
+      end
+    end
+  end
+
   describe '#create' do
     let(:tag_name) { 'Volunteers' }
     let(:request_body) { {name: tag_name} }


### PR DESCRIPTION
New methods for retrieving a collection of resources and a specific `Tag` by name.
Sadly `Tag` doesn't support querying / filtering with OData (https://actionnetwork.org/docs/v2#odata) so there's no option but to retrieve the list of all tags and go through each of them comparing the name.