### PR TITLE
Events API methods: Add update, enhance create

### DIFF
--- a/lib/action_network_rest/events.rb
+++ b/lib/action_network_rest/events.rb
@@ -32,6 +32,12 @@ module ActionNetworkRest
                                                            event_campaign_id: event_campaign_id)
     end
 
+    def update(id, event_data)
+      event_path = "#{base_path}#{url_escape(id)}"
+      response = client.put_request event_path, event_data
+      object_from_response(response)
+    end
+
     private
 
     def osdi_key

--- a/lib/action_network_rest/events.rb
+++ b/lib/action_network_rest/events.rb
@@ -16,11 +16,19 @@ module ActionNetworkRest
       end
     end
 
-    def create(event_data, creator_person_id: nil)
+    def create(event_data, creator_person_id: nil, organizer_person_id: nil)
       post_body = event_data
+
       if creator_person_id.present?
         creator_person_url = action_network_url("/people/#{url_escape(creator_person_id)}")
-        post_body['_links'] = { 'osdi:creator' => { href: creator_person_url } }
+        post_body['_links'] ||= {}
+        post_body['_links']['osdi:creator'] = { href: creator_person_url }
+      end
+
+      if organizer_person_id.present?
+        organizer_person_url = action_network_url("/people/#{url_escape(organizer_person_id)}")
+        post_body['_links'] ||= {}
+        post_body['_links']['osdi:organizer'] = { href: organizer_person_url }
       end
 
       response = client.post_request(base_path, post_body)

--- a/lib/action_network_rest/events.rb
+++ b/lib/action_network_rest/events.rb
@@ -16,8 +16,14 @@ module ActionNetworkRest
       end
     end
 
-    def create(event_data)
-      response = client.post_request(base_path, event_data)
+    def create(event_data, creator_person_id: nil)
+      post_body = event_data
+      if creator_person_id.present?
+        creator_person_url = action_network_url("/people/#{url_escape(creator_person_id)}")
+        post_body['_links'] = { 'osdi:creator' => { href: creator_person_url } }
+      end
+
+      response = client.post_request(base_path, post_body)
       object_from_response(response)
     end
 

--- a/spec/events_spec.rb
+++ b/spec/events_spec.rb
@@ -92,6 +92,43 @@ describe ActionNetworkRest::Events do
         expect(event.action_network_id).to eq '123-456-789-abc'
       end
     end
+
+    context 'with an organizer_person_id' do
+      let(:person_id) { 'c945d6fe-929e-11e3-a2e9-12313d316c29' }
+      let(:person_url) { "https://actionnetwork.org/api/v2/people/#{person_id}" }
+      let(:request_body) do
+        event_data.merge({ '_links' => { 'osdi:organizer' => { 'href' => person_url } } })
+      end
+
+      it 'should include a link to the organizer' do
+        event = subject.events.create(event_data, organizer_person_id: person_id)
+
+        expect(post_stub).to have_been_requested
+
+        expect(event.action_network_id).to eq '123-456-789-abc'
+      end
+    end
+
+    context 'with a creator_person_id and an organizer_person_id' do
+      let(:person_1_id) { 'c945d6fe-929e-11e3-a2e9-12313d316c29' }
+      let(:person_1_url) { "https://actionnetwork.org/api/v2/people/#{person_1_id}" }
+      let(:person_2_id) { '186d5368-28d3-4a49-99af-e70e40fadb6b' }
+      let(:person_2_url) { "https://actionnetwork.org/api/v2/people/#{person_2_id}" }
+      let(:request_body) do
+        event_data.merge({ '_links' => {
+          'osdi:creator' => { 'href' => person_1_url },
+          'osdi:organizer' => { 'href' => person_2_url }
+        } })
+      end
+
+      it 'should include links for both creator and organizer' do
+        event = subject.events.create(event_data, creator_person_id: person_1_id, organizer_person_id: person_2_id)
+
+        expect(post_stub).to have_been_requested
+
+        expect(event.action_network_id).to eq '123-456-789-abc'
+      end
+    end
   end
 
   describe '#update' do

--- a/spec/events_spec.rb
+++ b/spec/events_spec.rb
@@ -76,5 +76,21 @@ describe ActionNetworkRest::Events do
                                                    'somesystem:123')
       expect(event.action_network_id).to eq '123-456-789-abc'
     end
+
+    context 'with a creator_person_id' do
+      let(:person_id) { 'c945d6fe-929e-11e3-a2e9-12313d316c29' }
+      let(:person_url) { "https://actionnetwork.org/api/v2/people/#{person_id}" }
+      let(:request_body) do
+        event_data.merge({ '_links' => { 'osdi:creator' => { 'href' => person_url } } })
+      end
+
+      it 'should include a link to the creator' do
+        event = subject.events.create(event_data, creator_person_id: person_id)
+
+        expect(post_stub).to have_been_requested
+
+        expect(event.action_network_id).to eq '123-456-789-abc'
+      end
+    end
   end
 end

--- a/spec/events_spec.rb
+++ b/spec/events_spec.rb
@@ -93,4 +93,35 @@ describe ActionNetworkRest::Events do
       end
     end
   end
+
+  describe '#update' do
+    let(:event_data) do
+      {
+        identifiers: ['somesystem:123'],
+        title: 'My Great Event',
+        origin_system: 'Some System'
+      }
+    end
+    let(:event_id) { '123-456-789-abc' }
+    let(:response_body) do
+      {
+        identifiers: ['somesystem:123', 'action_network:123-456-789-abc'],
+        title: 'My Great Event',
+        origin_system: 'Some System'
+      }.to_json
+    end
+    let!(:put_stub) do
+      stub_actionnetwork_request("/events/#{event_id}", method: :put, body: event_data)
+        .to_return(status: 200, body: response_body)
+    end
+
+    it 'should PUT event data' do
+      updated_event = subject.events.update(event_id, event_data)
+
+      expect(put_stub).to have_been_requested
+
+      expect(updated_event.identifiers).to contain_exactly('action_network:123-456-789-abc',
+                                                           'somesystem:123')
+    end
+  end
 end

--- a/spec/events_spec.rb
+++ b/spec/events_spec.rb
@@ -45,4 +45,36 @@ describe ActionNetworkRest::Events do
       expect(stub_request).to have_been_requested
     end
   end
+
+  describe '#create' do
+    let(:event_data) do
+      {
+        identifiers: ['somesystem:123'],
+        title: 'My Great Event',
+        origin_system: 'Some System'
+      }
+    end
+    let(:request_body) { event_data }
+    let(:response_body) do
+      {
+        identifiers: ['somesystem:123', 'action_network:123-456-789-abc'],
+        title: 'My Great Event',
+        origin_system: 'Some System'
+      }.to_json
+    end
+    let!(:post_stub) do
+      stub_actionnetwork_request('/events/', method: :post, body: request_body)
+        .to_return(status: 200, body: response_body)
+    end
+
+    it 'should POST event data' do
+      event = subject.events.create(event_data)
+
+      expect(post_stub).to have_been_requested
+
+      expect(event.identifiers).to contain_exactly('action_network:123-456-789-abc',
+                                                   'somesystem:123')
+      expect(event.action_network_id).to eq '123-456-789-abc'
+    end
+  end
 end


### PR DESCRIPTION
This makes two enhancements to the `event` API methods:
- Adds support for `events.update`
- Allows passing `creator_person_id` and/or `organizer_person_id` to `events.create`, as a shortcut for setting osdi person links on the event

Documentation for reference: https://actionnetwork.org/docs/v2/events

We're not adding `events.delete` support, because the API does not support deletion.