### PR TITLE
Add support for updating event campaigns

### DIFF
--- a/lib/action_network_rest/event_campaigns.rb
+++ b/lib/action_network_rest/event_campaigns.rb
@@ -20,6 +20,12 @@ module ActionNetworkRest
       object_from_response(response)
     end
 
+    def update(id, event_campaign_data)
+      event_campaign_path = "#{base_path}#{url_escape(id)}"
+      response = client.put_request event_campaign_path, event_campaign_data
+      object_from_response(response)
+    end
+
     def events(event_id = nil)
       @_events ||= ActionNetworkRest::Events.new(event_campaign_id: event_campaign_id, event_id: event_id,
                                                  client: client)

--- a/spec/event_campaigns_spec.rb
+++ b/spec/event_campaigns_spec.rb
@@ -38,4 +38,35 @@ describe ActionNetworkRest::EventCampaigns do
       expect(stub_request).to have_been_requested
     end
   end
+
+  describe '#update' do
+    let(:campaign_data) do
+      {
+        identifiers: ['somesystem:123'],
+        title: 'My Great Event Campaign',
+        origin_system: 'Some System'
+      }
+    end
+    let(:campaign_id) { '2df5eb21-535a-433e-8440-a8a3f2107643' }
+    let(:response_body) do
+      {
+        identifiers: ['somesystem:123', "action_network:#{campaign_id}"],
+        title: 'My Great Event Campaign',
+        origin_system: 'Some System'
+      }.to_json
+    end
+    let!(:put_stub) do
+      stub_actionnetwork_request("/event_campaigns/#{campaign_id}", method: :put, body: campaign_data)
+        .to_return(status: 200, body: response_body)
+    end
+
+    it 'should PUT event campaign data' do
+      updated_event_campaign = subject.event_campaigns.update(campaign_id, campaign_data)
+
+      expect(put_stub).to have_been_requested
+
+      expect(updated_event_campaign.identifiers).to contain_exactly("action_network:#{campaign_id}",
+                                                                    'somesystem:123')
+    end
+  end
 end


### PR DESCRIPTION
This adds a `client.event_campaigns.update(id, data)` method that updates the event campaign. API endpoint docs: https://actionnetwork.org/docs/v2/event_campaigns#put