### PR TITLE
Replace old Travis CI config with Github Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Run CI Tests
+name: CI
 on: [push]
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: Run CI Tests
+on: [push]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@477b21f02be01bcb8030d50f37cfec92bfa615b6
+        with:
+          ruby-version: 2.7
+          bundler-cache: true
+      - run: bundle install
+      - run: bundle exec rspec
+  rubocop:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@477b21f02be01bcb8030d50f37cfec92bfa615b6
+        with:
+          ruby-version: 2.7
+          bundler-cache: true
+      - run: bundle install
+      - run: bundle exec rubocop

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,7 +4,11 @@ require:
 AllCops:
   NewCops: enable
   TargetRubyVersion: 2.6
+Metrics/AbcSize:
+  Enabled: false
 Metrics/BlockLength:
+  Enabled: false
+Metrics/MethodLength:
   Enabled: false
 Naming/AccessorMethodName:
   Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: ruby
-rvm:
-  - 2.7
-cache: bundler
-before_install:
-  - gem install bundler
-script:
-  - bundle exec rspec
-  - bundle exec rubocop

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Ruby client for interacting with the [ActionNetwork REST API](https://actionnetwork.org/docs/) from the engineering team at [ControlShift](https://www.controlshiftlabs.com/).
 
-[![Build Status](https://travis-ci.org/controlshift/action-network-rest.svg?branch=master)](https://travis-ci.org/controlshift/action-network-rest)
+[![CI Status](https://github.com/controlshift/action-network-rest/actions/workflows/ci.yml/badge.svg)](https://github.com/controlshift/action-network-rest/actions/workflows/ci.yml)
 
 ## Installation
 

--- a/spec/events_spec.rb
+++ b/spec/events_spec.rb
@@ -115,10 +115,12 @@ describe ActionNetworkRest::Events do
       let(:person_2_id) { '186d5368-28d3-4a49-99af-e70e40fadb6b' }
       let(:person_2_url) { "https://actionnetwork.org/api/v2/people/#{person_2_id}" }
       let(:request_body) do
-        event_data.merge({ '_links' => {
-          'osdi:creator' => { 'href' => person_1_url },
-          'osdi:organizer' => { 'href' => person_2_url }
-        } })
+        event_data.merge({
+                           '_links' => {
+                             'osdi:creator' => { 'href' => person_1_url },
+                             'osdi:organizer' => { 'href' => person_2_url }
+                           }
+                         })
       end
 
       it 'should include links for both creator and organizer' do


### PR DESCRIPTION
This sets up Github Actions to run our tests and rubocop on each commit, and removes the old Travis CI config that used to do that.

Also, gets rubocop passing again.