### PR TITLE
On event creation, raise if missing action network id on response

### DIFF
--- a/lib/action_network_rest/base.rb
+++ b/lib/action_network_rest/base.rb
@@ -23,7 +23,7 @@ module ActionNetworkRest
       CGI.escape(string.to_s)
     end
 
-    def set_action_network_id_on_object(obj)
+    def set_action_network_id_on_object(obj, action_network_id_required: false)
       # Takes an object which may contain an `identifiers` key, which may contain an action_network identifier
       # If so, we pull out the action_network identifier and stick it in a top-level key "action_network_id",
       # for the convenience of callers using the returned object.
@@ -38,14 +38,16 @@ module ActionNetworkRest
       end
       if qualified_actionnetwork_id.present?
         obj.action_network_id = qualified_actionnetwork_id.sub(/^action_network:/, '')
+      elsif action_network_id_required
+        raise ActionNetworkRest::Response::MissingActionNetworkId, obj.inspect
       end
 
       obj
     end
 
-    def object_from_response(response)
+    def object_from_response(response, action_network_id_required: false)
       obj = response.body
-      set_action_network_id_on_object(obj)
+      set_action_network_id_on_object(obj, action_network_id_required: action_network_id_required)
     end
 
     def action_network_url(path)

--- a/lib/action_network_rest/events.rb
+++ b/lib/action_network_rest/events.rb
@@ -32,7 +32,7 @@ module ActionNetworkRest
       end
 
       response = client.post_request(base_path, post_body)
-      object_from_response(response)
+      object_from_response(response, action_network_id_required: true)
     end
 
     def attendances

--- a/lib/action_network_rest/response/raise_error.rb
+++ b/lib/action_network_rest/response/raise_error.rb
@@ -29,6 +29,8 @@ module ActionNetworkRest
       end
     end
 
+    class MissingActionNetworkId < StandardError; end
+
     class MustSpecifyValidPersonId < StandardError; end
 
     class NotFoundError < StandardError; end

--- a/spec/events_spec.rb
+++ b/spec/events_spec.rb
@@ -131,6 +131,24 @@ describe ActionNetworkRest::Events do
         expect(event.action_network_id).to eq '123-456-789-abc'
       end
     end
+
+    context 'no action network id on response' do
+      let(:response_body) do
+        {
+          identifiers: ['somesystem:123'],
+          title: 'My Great Event',
+          origin_system: 'Some System'
+        }.to_json
+      end
+
+      it 'should raise' do
+        expect do
+          subject.events.create(event_data)
+        end.to raise_error(ActionNetworkRest::Response::MissingActionNetworkId)
+
+        expect(post_stub).to have_been_requested
+      end
+    end
   end
 
   describe '#update' do


### PR DESCRIPTION
We suspect that there is some silent error case where Action Network API does not return an action network identifier on an event creation attempt. This PR makes a change to raise an error in this case, so that consumers can be aware of when it happens and handle appropriately. 